### PR TITLE
Do not delete `EXTENDED_ARG` instructions that have no arg

### DIFF
--- a/bytecode/__init__.py
+++ b/bytecode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5'
+__version__ = '0.5.1'
 
 __all__ = ['Label', 'Instr', 'SetLineno', 'Bytecode',
            'ConcreteInstr', 'ConcreteBytecode',

--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -189,8 +189,10 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
                         extended_arg = (extended_arg << 8) + instr.arg
                     else:
                         extended_arg = instr.arg
-                    del instructions[index]
-                    continue
+
+                    if extended_arg > 0:
+                        del instructions[index]
+                        continue
 
                 if extended_arg is not None:
                     if _WORDCODE:

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -479,6 +479,54 @@ class BytecodeToConcreteTests(TestCase):
         self.assertListEqual(concrete.names, ['test', 'x'])
         self.assertListEqual(concrete.varnames, [])
 
+    def test_label3(self):
+        """
+        When you delete ``extended_arg`` that have a value of 0, the following
+        will fail when calling ``Bytecode.to_concrete_bytecode()`` because
+        it cant find a label to correspond to the jump target
+        """
+        code = get_code("""
+            def func(x):
+                if x == 1:
+                    return x +1
+                elif x == 2:
+                    return x + 1
+                elif x == 3:
+                    return x + 1
+                elif x == 4:
+                    return x + 1
+                elif x == 5:
+                    return x + 1
+                elif x == 6:
+                    return x + 1
+                elif x == 7:
+                    return x + 1
+                elif x == 8:
+                    return x + 1
+                elif x == 9:
+                    return x + 1
+                elif x == 10:
+                    return x + 1
+                elif x == 11:
+                    return x + 1
+                elif x == 12:
+                    return x + 1
+                elif x == 13:
+                    return x + 1
+                elif x == 14:
+                    return x + 1
+                elif x == 15:
+                    return x + 1
+                elif x == 16:
+                    return x + 1
+                elif x == 17:
+                    return x + 1 
+                return -1                   
+        """, function=True)
+        code = Bytecode.from_code(code)
+        concrete = code.to_concrete_bytecode()
+        self.assertIsInstance(concrete,ConcreteBytecode)
+
     def test_setlineno(self):
         # x = 7
         # y = 8

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -520,12 +520,12 @@ class BytecodeToConcreteTests(TestCase):
                 elif x == 16:
                     return x + 1
                 elif x == 17:
-                    return x + 1 
-                return -1                   
+                    return x + 1
+                return -1
         """, function=True)
         code = Bytecode.from_code(code)
         concrete = code.to_concrete_bytecode()
-        self.assertIsInstance(concrete,ConcreteBytecode)
+        self.assertIsInstance(concrete, ConcreteBytecode)
 
     def test_setlineno(self):
         # x = 7

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 #  - git commit -a -m "post-release"
 #  - git push
 
-VERSION = '0.5'
+VERSION = '0.5.1'
 
 DESCRIPTION = 'Python module to generate and modify bytecode'
 CLASSIFIERS = [


### PR DESCRIPTION
Thanks for the great library!  I'm using it [here](https://github.com/CityOfZion/neo-boa) with much enjoyment.

I've run into one issue where large `if/elif` trees fail parsing and I'll get an error similar to this:
```Traceback (most recent call last):
  File "/Users/thomassaunders/Workshop/bytecode/bytecode/tests/test_concrete.py", line 526, in test_label3
    code = Bytecode.from_code(code)
  File "/Users/thomassaunders/Workshop/bytecode/bytecode/bytecode.py", line 133, in from_code
    return concrete.to_bytecode()
  File "/Users/thomassaunders/Workshop/bytecode/bytecode/concrete.py", line 373, in to_bytecode
    label = labels[jump_target]
KeyError: 280
```

This PR fixes that issue, and I've added a test for this.  Would be interested in any feedback!
