### PR TITLE
better convergence of compute_jumps

### DIFF
--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -506,12 +506,12 @@ class _ConvertBytecodeToConcrete:
         self.varnames.extend(self.bytecode.argnames)
 
         self.concrete_instructions()
-        modified = self.compute_jumps()
-        if modified:
+        for step in range(0, 10):
             modified = self.compute_jumps()
-            if modified:
-                raise RuntimeError("compute_jumps() must not modify jumps "
-                                   "at the second iteration")
+            if not modified:
+                break
+        else:
+            raise RuntimeError("compute_jumps() failed to converge")
 
         consts = [None] * len(self.consts)
         for item, index in self.consts.items():


### PR DESCRIPTION
TLDR: Two passes of compute_jumps() is not sufficient.

Consider the following sequence of instructions (assuming Python 3.6 / wordcode):

> Label1:
>     JUMP_ABSOLUTE Label2
>     ...126 instructions...
> Label2:
>     NOP

On first pass of `compute_jumps()`, Label2 will be at address 254, so that value encodes into the single byte arg of JUMP_ABSOLUTE.  All is well.

Now imagine instead that one of the intervening "...126 instructions..." needed to have an EXTENDED_ARG prepended to it.  So the initial pass of compute_jumps() will return True (i.e. modified).  So we call compute_jumps() again...

Now during this second pass of compute_jumps(), Label2 is seen to be at address 256, so the offset from "JUMP_FORWARD Label2" is 256 and cannot be encoded in a single byte, so...  we prepend EXTENDED_ARG, remember that we modified that code, return True, and then...

The calling code in `to_concrete_bytecode()` raises if the second compute_jumps() also has modifications.

Clearly more than two passes can be necessary.

You could arrange this scenario pre-wordcode as well, but since the jumps have 16 bit offsets you need a much larger function before this becomes a problem.

Given the current algorithm of just calling compute_args() until it converges, it needs to be called more than twice.  I'm not sure what the upper limit could be.  But I'm not comfortable with it iterating forever, so I changed the upper limit to 10 passes before it raises.

I think ultimately this should probably have a better algorithm that doesn't need to iterate over every instruction until it converges on a solution, but I haven't read compile.c yet to see how it's done there.
