### PR TITLE
Fix the handling EXTENDED_ARG 0

### DIFF
--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -30,9 +30,13 @@ class ConcreteInstr(Instr):
     It has a read-only size attribute.
     """
 
-    __slots__ = ('_size',)
+    __slots__ = ('_size', '_extended_args')
 
-    def __init__(self, name, arg=UNSET, *, lineno=None):
+    def __init__(self, name, arg=UNSET, *, lineno=None, extended_args=None):
+        # Allow to remember a potentially meaningless EXTENDED_ARG emitted by
+        # Python to properly compute the size and avoid messing up the jump
+        # targets
+        self._extended_args = extended_args
         self._set(name, arg, lineno)
 
     def _check_arg(self, name, opcode, arg):
@@ -53,12 +57,16 @@ class ConcreteInstr(Instr):
                 while arg > 0xff:
                     size += 2
                     arg >>= 8
+            if self._extended_args is not None:
+                size = 2 + 2*self._extended_args
         else:
             size = 1
             if arg is not UNSET:
                 size += 2
                 if arg > 0xffff:
                     size += 3
+                if self._extended_args is not None:
+                    size = 1 + 3*self._extended_args
         self._size = size
 
     @property
@@ -175,13 +183,20 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
             offset += instr.size
 
         # replace jump targets with blocks
+        # HINT : in some cases Python generate useless EXTENDED_ARG opcode
+        # with a value of zero. Such opcodes do not increases the size of the
+        # following opcode the way a normal EXTENDED_ARG does. As a
+        # consequence, they need to be tracked manually as otherwise the
+        # offsets in jump targets can end up being wrong.
         if not extended_arg:
+            nb_extended_args = 0
             extended_arg = None
             index = 0
             while index < len(instructions):
                 instr = instructions[index]
 
                 if instr.name == 'EXTENDED_ARG':
+                    nb_extended_args += 1
                     if extended_arg is not None:
                         if not _WORDCODE:
                             raise ValueError("EXTENDED_ARG followed "
@@ -190,9 +205,8 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
                     else:
                         extended_arg = instr.arg
 
-                    if extended_arg > 0:
-                        del instructions[index]
-                        continue
+                    del instructions[index]
+                    continue
 
                 if extended_arg is not None:
                     if _WORDCODE:
@@ -201,8 +215,10 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
                         arg = (extended_arg << 16) + instr.arg
                     extended_arg = None
 
-                    instr = ConcreteInstr(instr.name, arg, lineno=instr.lineno)
+                    instr = ConcreteInstr(instr.name, arg, lineno=instr.lineno,
+                                          extended_args=nb_extended_args)
                     instructions[index] = instr
+                    nb_extended_args = 0
 
                 index += 1
 

--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -275,6 +275,9 @@ class Instr:
         # a stack_effect indepent of their argument.
         arg = (self._arg if isinstance(self._arg, int) else
                0 if self._opcode >= _opcode.HAVE_ARGUMENT else None)
+        # EXTENDED_ARG has no stack effect but is not supported by dis
+        if self._name == 'EXTENDED_ARG':
+            return 0
         return dis.stack_effect(self._opcode, arg)
 
     def copy(self):

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -454,6 +454,16 @@ class CFGStacksizeComputationTests(TestCase):
                      Instr("STORE_NAME", 'z')])
         self.assertEqual(code.compute_stacksize(), 1)
 
+    def test_handling_of_extended_arg(self):
+        code = Bytecode()
+        code.first_lineno = 3
+        code.extend([Instr("LOAD_CONST", 7),
+                     Instr("STORE_NAME", 'x'),
+                     Instr("EXTENDED_ARG", 1),
+                     Instr("LOAD_CONST", 8),
+                     Instr("STORE_NAME", 'y')])
+        self.assertEqual(code.compute_stacksize(), 1)
+
     def test_invalid_stacksize(self):
         code = Bytecode()
         code.extend([Instr("STORE_NAME", 'x')])

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -540,10 +540,6 @@ class BytecodeToConcreteTests(TestCase):
                     return x + 1
                 return -1
         """, function=True)
-        bcode = ConcreteBytecode.from_code(code).to_bytecode()
-        concrete = bcode.to_concrete_bytecode()
-        self.assertIsInstance(concrete, ConcreteBytecode)
-
         bcode = Bytecode.from_code(code)
         concrete = bcode.to_concrete_bytecode()
         self.assertIsInstance(concrete, ConcreteBytecode)


### PR DESCRIPTION
The issue identified/fixed in PR 24 results from the fact that CPython sometimes emits meaningless EXTENDED_ARG (meaningless in that the argument fits in 8 bits). As a consequence, the size inferred from the argument leads to the wrong offset (since we miss one opcode) and breaks jump targets. To be safe against this, we manually keep track of the number of seen extended args to compute the size. Ideally CPython should not emit such bytecode.

This patch fixes #25 since we never leave EXTENDED_ARG opcodes when we are not supposed to. However, it should be possible to convert back a ConcreteBytecode obtained use extended_arg=True, so we support computing its stack_effect.