### PR TITLE
updates for handling Python3.7

### DIFF
--- a/bytecode/cfg.py
+++ b/bytecode/cfg.py
@@ -2,7 +2,6 @@
 import bytecode as _bytecode
 from bytecode.concrete import ConcreteInstr
 from bytecode.instr import Label, SetLineno, Instr
-import logging                                  # XYZZY
 
 
 class BasicBlock(_bytecode._InstrList):
@@ -49,12 +48,8 @@ class BasicBlock(_bytecode._InstrList):
         return target_block
 
 
-logger = logging.getLogger(__name__)           # XYZZY
-
-
 def _compute_stack_size(block, size, maxsize):
 
-    logger.debug("%s:  size=%d maxsize=%d", block.name, size, maxsize)
     if block.seen or block.startsize >= size:
         return maxsize
 
@@ -66,14 +61,6 @@ def _compute_stack_size(block, size, maxsize):
             msg = 'Failed to compute stacksize, got negative size'
             raise RuntimeError(msg)
         maxsize = max(maxsize, size)
-
-    def show(jump):
-        nonlocal size
-        nonlocal maxsize
-        nonlocal instr
-        logger.debug("    %s(%d) %s", instr.name, instr.opcode, instr.arg)
-        logger.debug("    ;; effect=%d size=%d maxsize=%d jump=%d",
-                     instr.stack_effect(jump), size, maxsize, jump)
 
     block.seen = True
     block.startsize = size
@@ -87,36 +74,23 @@ def _compute_stack_size(block, size, maxsize):
             # first compute the taken-jump path
             before_size = size
             update_size(instr.stack_effect(1))
-            show(1)
             target_size = size
-            logger.debug("    ;; taken jmp from %s to %s, target_size=%d, maxsize=%d",
-                         block.name, instr.arg.name, target_size, maxsize)
             maxsize = _compute_stack_size(instr.arg, target_size, maxsize)
-            logger.debug("    ;; taken jmp from %s to %s, returns %d",
-                         block.name, instr.arg.name, maxsize)
             size = before_size
 
             if instr.is_uncond_jump():
                 block.seen = False
-                logger.debug("    ;; %s returns %d (is_uncond_jump)",
-                             block.name, maxsize)
                 return maxsize
 
             # compute non-taken-jump path
             update_size(instr.stack_effect(0))
-            show(0)
 
         else:  # no jump
             update_size(instr.stack_effect())
-            show(-1)                            # XYZZY
-    logger.debug("    ;; %s ended with %d", block.name, maxsize)
     if block.next_block:
-        logger.debug("    ;; %s falling through to %s",
-                     block.name, block.next_block.name)
         maxsize = _compute_stack_size(block.next_block, size, maxsize)
 
     block.seen = 0
-    logger.debug("    ;; %s returning %d", block.name, maxsize)
     return maxsize
 
 
@@ -151,7 +125,6 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
             return 0
 
         for block in self:
-            block.name = "block%d" % (1 + self.get_block_index(block))  # XYZZY
             block.seen = False
             block.startsize = -32768  # INT_MIN
 

--- a/bytecode/cfg.py
+++ b/bytecode/cfg.py
@@ -61,7 +61,7 @@ def _compute_stack_size(block, size, maxsize):
         if isinstance(instr, SetLineno):
             continue
 
-        size += instr.stack_effect
+        size += instr.stack_effect()
         maxsize = max(maxsize, size)
 
         if size < 0:

--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -269,7 +269,6 @@ class Instr:
     def lineno(self, lineno):
         self._set(self._name, self._arg, lineno)
 
-    @property
     def stack_effect(self):
         # All opcodes whose arguments are not represented by integers have
         # a stack_effect indepent of their argument.

--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -2,6 +2,7 @@ import enum
 import dis
 import math
 import opcode as _opcode
+import sys
 import types
 
 import bytecode as _bytecode
@@ -144,6 +145,37 @@ def _check_arg_int(name, arg):
                          % name)
 
 
+_stack_effects = {
+    # NOTE: the entries are all 3-tuples, to leverage tuple[-1] being the last
+    # value.  Entry[0] is non-taken jumps.  Entry[1] is for taken jumps.
+    # Entry[2] is the max of the others.  It is maintained manually here but
+    # verified in a unittest.  Entry [2] is so that we do not need a runtime
+    # test when callers of stack_effect() specify "jump=-1".  Remember that
+    # Entry[2] is also addressable as Entry[-1].
+
+    # opcodes not in dis.stack_effect
+    _opcode.opmap['EXTENDED_ARG']: (0, 0, 0),
+    _opcode.opmap['NOP']: (0, 0, 0),
+
+    # Jump taken/not-taken are different:
+    _opcode.opmap['JUMP_IF_TRUE_OR_POP']: (-1, 0, 0),
+    _opcode.opmap['JUMP_IF_FALSE_OR_POP']: (-1, 0, 0),
+    _opcode.opmap['FOR_ITER']: (1, -1, 1),
+    _opcode.opmap['SETUP_WITH']: (1, 6, 6),
+    _opcode.opmap['SETUP_ASYNC_WITH']: (0, 5, 5),
+    _opcode.opmap['SETUP_EXCEPT']: (0, 6, 6),   # as of 3.7, below for <=3.6
+    _opcode.opmap['SETUP_FINALLY']: (0, 6, 6),  # as of 3.7, below for <=3.6
+}
+
+# More stack effect values that are unique to the version of Python.
+if not (sys.version_info >= (3, 7)):
+    _stack_effects.update({
+        _opcode.opmap['SETUP_WITH']: (7, 7, 7),
+        _opcode.opmap['SETUP_EXCEPT']: (6, 9, 9),
+        _opcode.opmap['SETUP_FINALLY']: (6, 9, 9),
+    })
+
+
 class Instr:
     """Abstract instruction."""
 
@@ -269,7 +301,25 @@ class Instr:
     def lineno(self, lineno):
         self._set(self._name, self._arg, lineno)
 
-    def stack_effect(self):
+    def stack_effect(self, jump=-1):
+        """Return stack effect of the instruction.
+
+        Some opcodes have different stack effect when jump to the target and
+        when not jump. The 'jump' parameter specifies the case:
+
+        * 0 -- when not jump
+        * 1 -- when jump
+        * -1 -- maximal
+        """
+
+        effect = _stack_effects.get(self._opcode, None)
+        if effect is not None:
+            return effect[jump]
+
+        # TODO: if dis.stack_effect ever expands to take the 'jump' parameter
+        # then we should pass that through, and perhaps remove some of the
+        # overrides that are set up in _init_stack_effects()
+
         # All opcodes whose arguments are not represented by integers have
         # a stack_effect indepent of their argument.
         arg = (self._arg if isinstance(self._arg, int) else

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -436,6 +436,16 @@ class CFGStacksizeComputationTests(TestCase):
         code = func.__code__
         bytecode = Bytecode.from_code(code)
         cfg = ControlFlowGraph.from_bytecode(bytecode)
+
+        # XYZZY import bytecode as _bytecode
+        # XYZZY _bytecode.dump_bytecode(cfg)
+        # XYZZY for i in bytecode:
+        # XYZZY     print("%s %s" % (i,
+        # XYZZY                      i.stack_effect if isinstance(i, Instr) else "???"))
+        # XYZZY print("")
+        # XYZZY print("code.co_stacksize=%d" % code.co_stacksize)
+        # XYZZY print("cfg.compute_stacksize=%d" % cfg.compute_stacksize())
+
         self.assertEqual(code.co_stacksize, cfg.compute_stacksize())
 
     def test_empty_code(self):
@@ -516,8 +526,6 @@ class CFGStacksizeComputationTests(TestCase):
             with open(arg1) as f:
                 return f.read()
 
-        import dis
-        dis.dis(test.__code__)
         self.check_stack_size(test)
 
     def test_stack_size_computation_try_except(self):

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -436,16 +436,6 @@ class CFGStacksizeComputationTests(TestCase):
         code = func.__code__
         bytecode = Bytecode.from_code(code)
         cfg = ControlFlowGraph.from_bytecode(bytecode)
-
-        # XYZZY import bytecode as _bytecode
-        # XYZZY _bytecode.dump_bytecode(cfg)
-        # XYZZY for i in bytecode:
-        # XYZZY     print("%s %s" % (i,
-        # XYZZY                      i.stack_effect if isinstance(i, Instr) else "???"))
-        # XYZZY print("")
-        # XYZZY print("code.co_stacksize=%d" % code.co_stacksize)
-        # XYZZY print("cfg.compute_stacksize=%d" % cfg.compute_stacksize())
-
         self.assertEqual(code.co_stacksize, cfg.compute_stacksize())
 
     def test_empty_code(self):

--- a/bytecode/tests/test_instr.py
+++ b/bytecode/tests/test_instr.py
@@ -203,6 +203,17 @@ class InstrTests(TestCase):
             self.assertEqual(3, len(effect), msg)
             self.assertEqual(effect[-1], max(effect[0], effect[1]), msg)
 
+        # Verify all opcodes are handled.  Use ConcreteInstr instead of Instr
+        # because it doesn't care what kind of argument it is constructed
+        # with.
+        from bytecode.concrete import ConcreteInstr
+        for name, op in opcode.opmap.items():
+            if op < opcode.HAVE_ARGUMENT:
+                instr = ConcreteInstr(name)
+            else:
+                instr = ConcreteInstr(name, 0)
+            effect = instr.stack_effect(-1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bytecode/tests/test_instr.py
+++ b/bytecode/tests/test_instr.py
@@ -191,6 +191,18 @@ class InstrTests(TestCase):
         self.assertNotEqual(Instr('LOAD_CONST', frozenset({0})),
                             Instr('LOAD_CONST', frozenset({0.0})))
 
+    def test_stack_effects(self):
+        # Manually dig through the internal overrides of dis.stack_effect to
+        # verify that they make sense.  They should all be 3-tuples, and the
+        # last entry should be the max of the other two.
+
+        import bytecode.instr
+
+        for op, effect in bytecode.instr._stack_effects.items():
+            msg = "opcode=%s" % opcode.opname[op]
+            self.assertEqual(3, len(effect), msg)
+            self.assertEqual(effect[-1], max(effect[0], effect[1]), msg)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -93,11 +93,6 @@ Instr
       Operation code (``int``). Setting the operation code updates the
       :attr:`name` attribute.
 
-   .. attribute:: stack_effect
-
-       Operation effect on the stack size as computed by
-       :func:`dis.stack_effect`.
-
    .. versionchanged:: 0.3
       The ``op`` attribute was renamed to :attr:`opcode`.
 
@@ -157,6 +152,11 @@ Instr
 
       .. versionchanged:: 0.3
          The *lineno* parameter has been removed.
+
+   .. method:: stack_effect() -> int
+
+       Operation effect on the stack size as computed by
+       :func:`dis.stack_effect`.
 
 
 ConcreteInstr

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -153,11 +153,15 @@ Instr
       .. versionchanged:: 0.3
          The *lineno* parameter has been removed.
 
-   .. method:: stack_effect() -> int
+   .. method:: stack_effect(jump:int = -1) -> int
 
-       Operation effect on the stack size as computed by
-       :func:`dis.stack_effect`.
+      Operation effect on the stack size as computed by
+      :func:`dis.stack_effect`.
 
+      The *jump* argument takes one of three values.  -1 (default) requests
+      the largest known stack effect.  This works fine with most instructions.
+      0 means return the stack effect for non-taken branches.  1 means return
+      the stack effect for taken branches.
 
 ConcreteInstr
 -------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, py35, py36, pep8
+envlist = py3, py35, py36, py37, pep8
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
These changes make the tests pass with Python 3.7.0b3.  I made a few enhancements to tests, but the changes were mostly functional.  In particular, related to changes in dis.stack_effect and compile.c.

In particular, compile.c seems to do a better job in 3.7 of computing stacksize, by leveraging new knowledge of separate stack_effect for taken vs untaken branches.

I have modeled this in bytecode by having Instr.stack_effect() take a "jump" argument as in compile.c.  Note that this is supported for all versions, not just 3.7.  Note also that this is a **breaking change** because stack_effect used to be a property.

I also rewrote most of the logic in _compute_stack_effect().  The previous code tested or several instructions, embedding taken/not-taken knowledge in this function.  Since that knowledge is now exposed in Instr.stack_effect the logic here can be simpler. 

I haven't yet tried running any of my own code which uses bytecode, as I'm only just starting to test under 3.7.