### PR TITLE
bypass some temporary ControlFlowGraph objects

### DIFF
--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -136,9 +136,10 @@ class Bytecode(_InstrList, BaseBytecode):
         cfg = _bytecode.ControlFlowGraph.from_bytecode(self)
         return cfg.compute_stacksize()
 
-    def to_code(self, compute_jumps_passes=None):
-        return self.to_concrete_bytecode(
-            compute_jumps_passes=compute_jumps_passes).to_code()
+    def to_code(self, compute_jumps_passes=None, stacksize=None):
+        bc = self.to_concrete_bytecode(
+            compute_jumps_passes=compute_jumps_passes)
+        return bc.to_code(stacksize=stacksize)
 
     def to_concrete_bytecode(self, compute_jumps_passes=None):
         converter = _bytecode._ConvertBytecodeToConcrete(self)

--- a/bytecode/cfg.py
+++ b/bytecode/cfg.py
@@ -319,3 +319,10 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
         bytecode[:] = instructions
 
         return bytecode
+
+    def to_code(self, stacksize=None):
+        """Convert to code."""
+        if stacksize is None:
+            stacksize = self.compute_stacksize()
+        bc = self.to_bytecode()
+        return bc.to_code(stacksize=stacksize)

--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -316,11 +316,12 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
         cfg = _bytecode.ControlFlowGraph.from_bytecode(bytecode)
         return cfg.compute_stacksize()
 
-    def to_code(self):
+    def to_code(self, stacksize=None):
         code_str, linenos = self._assemble_code()
         lnotab = self._assemble_lnotab(self.first_lineno, linenos)
         nlocals = len(self.varnames)
-        stacksize = self.compute_stacksize()
+        if stacksize is None:
+            stacksize = self.compute_stacksize()
         return types.CodeType(self.argcount,
                               self.kwonlyargcount,
                               nlocals,

--- a/bytecode/peephole_opt.py
+++ b/bytecode/peephole_opt.py
@@ -456,8 +456,8 @@ class PeepholeOptimizer:
         # FIXME: merge following blocks if block1 does not contain any
         # jump and block1.next_block is block2
 
-    def _optimize(self, code):
-        self.code = code
+    def optimize_cfg(self, cfg):
+        self.code = cfg
         self.const_stack = []
 
         self.remove_dead_blocks()
@@ -472,7 +472,7 @@ class PeepholeOptimizer:
         bytecode = Bytecode.from_code(code_obj)
         cfg = ControlFlowGraph.from_bytecode(bytecode)
 
-        self._optimize(cfg)
+        self.optimize_cfg(cfg)
 
         bytecode = cfg.to_bytecode()
         code = bytecode.to_code()

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -104,6 +104,22 @@ class BytecodeTests(TestCase):
                      ConcreteInstr("LOAD_CONST", 2, lineno=5),
                      ConcreteInstr("STORE_NAME", 2, lineno=5)])
 
+    def test_to_code(self):
+        code = Bytecode()
+        code.first_lineno = 50
+        code.extend([Instr("LOAD_NAME", "print"),
+                     Instr("LOAD_CONST", "%s"),
+                     Instr("LOAD_GLOBAL", "a"),
+                     Instr("BINARY_MODULO"),
+                     Instr("CALL_FUNCTION", 1),
+                     Instr("RETURN_VALUE")])
+        co = code.to_code()
+        # hopefully this is obvious from inspection? :-)
+        self.assertEqual(co.co_stacksize, 3)
+
+        co = code.to_code(stacksize=42)
+        self.assertEqual(co.co_stacksize, 42)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -417,6 +417,11 @@ class BytecodeBlocksFunctionalTests(TestCase):
         self.assertEqual(code.co_name, 'func')
         self.assertEqual(code.co_firstlineno, 3)
 
+        # verify stacksize argument is honored
+        explicit_stacksize = code.co_stacksize + 42
+        code = bytecode.to_bytecode().to_code(stacksize=explicit_stacksize)
+        self.assertEqual(code.co_stacksize, explicit_stacksize)
+
     def test_get_block_index(self):
         blocks = ControlFlowGraph()
         block0 = blocks[0]

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -401,7 +401,7 @@ class BytecodeBlocksFunctionalTests(TestCase):
                         b'|\x05\x00'
                         b'S')
 
-        code = bytecode.to_bytecode().to_code()
+        code = bytecode.to_code()
         self.assertEqual(code.co_consts, (None, 3))
         self.assertEqual(code.co_argcount, 3)
         self.assertEqual(code.co_kwonlyargcount, 2)
@@ -419,7 +419,7 @@ class BytecodeBlocksFunctionalTests(TestCase):
 
         # verify stacksize argument is honored
         explicit_stacksize = code.co_stacksize + 42
-        code = bytecode.to_bytecode().to_code(stacksize=explicit_stacksize)
+        code = bytecode.to_code(stacksize=explicit_stacksize)
         self.assertEqual(code.co_stacksize, explicit_stacksize)
 
     def test_get_block_index(self):

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -359,6 +359,26 @@ class ConcreteBytecodeTests(TestCase):
             code.co_code,
             b'\x94\x01\x89\x01' if WORDCODE else b'\x94\x01\x00\x89\x01\x00')
 
+    def test_explicit_stacksize(self):
+        # Passing stacksize=... to ConcreteBytecode.to_code should result in a
+        # code object with the specified stacksize.  We pass some silly values
+        # and assert that they are honored.
+        code_obj = get_code("print('%s' % (a,b,c))")
+        original_stacksize = code_obj.co_stacksize
+        concrete = ConcreteBytecode.from_code(code_obj)
+
+        # First with something bigger than necessary.
+        explicit_stacksize = original_stacksize + 42
+        new_code_obj = concrete.to_code(stacksize=explicit_stacksize)
+        self.assertEqual(new_code_obj.co_stacksize, explicit_stacksize)
+
+        # Then with something bogus.  We probably don't want to advertise this
+        # in the documentation.  If this fails then decide if it's for good
+        # reason, and remove if so.
+        explicit_stacksize = 0
+        new_code_obj = concrete.to_code(stacksize=explicit_stacksize)
+        self.assertEqual(new_code_obj.co_stacksize, explicit_stacksize)
+
 
 class ConcreteFromCodeTests(TestCase):
 

--- a/bytecode/tests/test_peephole_opt.py
+++ b/bytecode/tests/test_peephole_opt.py
@@ -12,14 +12,14 @@ class Tests(TestCase):
         if isinstance(code, Bytecode):
             code = ControlFlowGraph.from_bytecode(code)
         optimizer = peephole_opt.PeepholeOptimizer()
-        optimizer._optimize(code)
+        optimizer.optimize_cfg(code)
         return code
 
     def check(self, code, *expected):
         if isinstance(code, Bytecode):
             code = ControlFlowGraph.from_bytecode(code)
         optimizer = peephole_opt.PeepholeOptimizer()
-        optimizer._optimize(code)
+        optimizer.optimize_cfg(code)
         code = code.to_bytecode()
 
         try:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -366,13 +366,15 @@ Bytecode
       3.6.5 unittests on OS X 11.13 results in 264996 compiled methods, only
       one of which requires 5 passes, and none requiring more.
 
-   .. method:: to_code(compute_jumps_passes: int = None) -> types.CodeType
+   .. method:: to_code(compute_jumps_passes: int = None, stacksize: int = None) -> types.CodeType
 
       Convert to a Python code object.
 
       It is based on :meth:`to_concrete_bytecode` and so resolve jump targets.
 
       *compute_jumps_passes*: see :meth:`to_concrete_bytecode`
+
+      *stacksize*: see :meth:`ConcreteBytecode.to_code`
 
    .. method:: compute_stacksize() -> int
 
@@ -428,12 +430,17 @@ ConcreteBytecode
 
    Methods:
 
-   .. method:: to_code() -> types.CodeType
+   .. method:: to_code(stacksize: int = None) -> types.CodeType
 
       Convert to a Python code object.
 
       On Python older than 3.6, raise an exception on negative line number
       delta.
+
+      *stacksize* Allows caller to explicitly specify a stacksize.  If not
+      specified a ControlFlowGraph is created internally in order to call
+      ControlFlowGraph.compute_stacksize().  It's cheaper to pass a value if
+      the value is known.
 
    .. method:: to_bytecode() -> Bytecode
 
@@ -556,6 +563,10 @@ ControlFlowGraph
 
       Update the object flags by calling :py:func:infer_flags on itself.
 
+   .. method:: to_code(stacksize: int = None)
+
+      Convert to a Python code object.  Refer to descriptions of
+      :meth:`Bytecode.to_code` and :meth:`ConcreteBytecode.to_code`.
 
 Cell and Free Variables
 =======================

--- a/doc/peephole.rst
+++ b/doc/peephole.rst
@@ -23,6 +23,16 @@ Content of the ``bytecode.peephole_opt`` module:
 
       Return a new optimized Python code object.
 
+      Note:  This method will disassemble code to a ConcreteBytecode, then a
+      Bytecode, then a ControlFlowGraph.  Then the CFG is optimized.  And then
+      the optimized CFG is converted back to a Bytecode, ConcreteBytecode, and
+      then code.  Depending on what you are doing you may get better
+      performance by calling :meth:`optimize_cfg`.
+
+   .. method:: optimize_cfg(cfg: ControlFlowGraph)
+
+      Optimizes an existing ControlFlowGraph.  The specified CFG is modified
+      in-place.
 
 .. class:: CodeTransformer
 


### PR DESCRIPTION
I noticed that converting Bytecode back to executable code has a habit of creating temporary ControlFlowGraphs for the sole purpose of computing stacksize.  My own pet uses of this module have been to build a ControlFlowGraph, it seems wasteful to have one of those objects, then have a temporary one created all over again just to compute the stacksize.  

Similarly, PeepholeOptimizer.optimize constructs a ControlFlowGraph from the passed Bytecode.  So also wasteful if you already have a ControlFlowGraph.

So in a nutshell.. this make PeepholeOptimizer.optimize_cfg() a public method.  This used to just be the private "_optimize()".  It's a simple change.

Then the to_code() methods on the different classes allow a stacksize to be passed in, with the intent being that if you have a CFG and can compute the stacksize that you're better off just using that.  It also allows you to specify a different stacksize if you think you know better: maybe you want to blow up CPython's stack (stacksize=big_number) or overflow the stack (stacksize=0) although I haven't tested those.
