### PR TITLE
Do not depend on aenum on Python 3.6+.

### DIFF
--- a/bytecode/flags.py
+++ b/bytecode/flags.py
@@ -1,6 +1,9 @@
 # alias to keep the 'bytecode' variable free
 import bytecode as _bytecode
-from aenum import IntFlag
+try:
+    from enum import IntFlag
+except ImportError:
+    from aenum import IntFlag
 
 
 class CompilerFlags(IntFlag):

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def main():
         'author_email': 'victor.stinner@gmail.com',
         'classifiers': CLASSIFIERS,
         'packages': ['bytecode', 'bytecode.tests'],
-        'install_requires': ['aenum >=2.0']
+        'install_requires': ['aenum >=2.0;python_version<"3.6"']
     }
     setup(**options)
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps=
     nose
     coverage
     codecov>=1.4.0
-    aenum>=2.0
+    aenum>=2.0;python_version<"3.6"
 commands=
     nosetests --with-coverage -v bytecode.tests
     codecov -e TOXENV
@@ -16,7 +16,7 @@ commands=
 basepython = python3
 deps=
     flake8
-    aenum>=2.0
+    aenum>=2.0;python_version<"3.6"
 commands =
     flake8 bytecode setup.py
 


### PR DESCRIPTION
Closes #39.