### PR TITLE
Fix calculating the stack effect for opcodes with arguments.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,10 +11,14 @@ New features:
   optimizations PR #34
 
 API changes:
+
 - `stack_effect` is now a method of `Instr` and not as property anymore. PR #29
 
 Bugfixes:
-- Avoid throwing `OverflowError` when applying `stack_effect` on valid `Instr` objects. PR #43
+
+- Avoid throwing `OverflowError` when applying `stack_effect` on valid `Instr`
+  objects. PR #43, PR #44
+
 
 2018-04-15: Version 0.7.0
 -------------------------


### PR DESCRIPTION
Instead of support a whitelist for opcodes whose stack effect
depends on its argument, it is better to ignore an argument only
for opcodes that can have an ambiguous integer argument
(i.e. refer to an integer constant).

Correctly fixes #38.