### PR TITLE
Allow to copy and slice Bytecode

### DIFF
--- a/bytecode/__init__.py
+++ b/bytecode/__init__.py
@@ -7,7 +7,7 @@ __all__ = ['Label', 'Instr', 'SetLineno', 'Bytecode',
 from bytecode.flags import CompilerFlags
 from bytecode.instr import (UNSET, Label, SetLineno, Instr, CellVar, FreeVar,   # noqa
                             Compare)
-from bytecode.bytecode import BaseBytecode, _InstrList, Bytecode   # noqa
+from bytecode.bytecode import BaseBytecode, _BaseBytecodeList, _InstrList, Bytecode   # noqa
 from bytecode.concrete import (ConcreteInstr, ConcreteBytecode,   # noqa
                                # import needed to use it in bytecode.py
                                _ConvertBytecodeToConcrete)

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -187,6 +187,11 @@ class Bytecode(_InstrList, _BaseBytecodeList):
                              "but %s was found"
                              % type(instr).__name__)
 
+    def _copy_attr_from(self, bytecode):
+        super()._copy_attr_from(bytecode)
+        if isinstance(bytecode, Bytecode):
+            self.argnames = bytecode.argnames
+
     @staticmethod
     def from_code(code):
         concrete = _bytecode.ConcreteBytecode.from_code(code)

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -79,6 +79,32 @@ class BaseBytecode:
         self.flags = infer_flags(self, is_async)
 
 
+class _BaseBytecodeList(BaseBytecode, list):
+    """List subclass providing type stable slicing and copying.
+
+    """
+    def __getitem__(self, index):
+        value = super().__getitem__(index)
+        if isinstance(index, slice):
+            value = type(self)(value)
+            value._copy_attr_from(self)
+
+        return value
+
+    def copy(self):
+        new = type(self)(super().copy())
+        new._copy_attr_from(self)
+        return new
+
+    def __iter__(self):
+        instructions = super().__iter__()
+        for instr in instructions:
+            self._check_instr(instr)
+            yield instr
+
+    def _check_instr(self, instr):
+        raise NotImplementedError()
+
 class _InstrList(list):
 
     def _flat(self):

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -131,6 +131,7 @@ class _BaseBytecodeList(BaseBytecode, list):
     def _check_instr(self, instr):
         raise NotImplementedError()
 
+
 class _InstrList(list):
 
     def _flat(self):

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -109,6 +109,9 @@ class _BaseBytecodeList(BaseBytecode, list):
                 set_lineno = instr.lineno
                 lineno_pos.append(pos)
                 continue
+            # Filter out Labels
+            if not isinstance(instr, Instr):
+                continue
             if set_lineno is not None:
                 instr.lineno = set_lineno
             elif instr.lineno is None:

--- a/bytecode/cfg.py
+++ b/bytecode/cfg.py
@@ -35,6 +35,19 @@ class BasicBlock(_bytecode._InstrList):
 
             yield instr
 
+    def __getitem__(self, index):
+        value = super().__getitem__(index)
+        if isinstance(index, slice):
+            value = type(self)(value)
+            value.next_block = self.next_block
+
+        return value
+
+    def copy(self):
+        new = type(self)(super().copy())
+        new.next_block = self.next_block
+        return new
+
     def get_jump(self):
         if not self:
             return None

--- a/bytecode/cfg.py
+++ b/bytecode/cfg.py
@@ -48,6 +48,31 @@ class BasicBlock(_bytecode._InstrList):
         new.next_block = self.next_block
         return new
 
+    def legalize(self, first_lineno):
+        """Check that all the element of the list are valid and remove SetLineno.
+
+        """
+        lineno_pos = []
+        set_lineno = None
+        current_lineno = first_lineno
+
+        for pos, instr in enumerate(self):
+            if isinstance(instr, SetLineno):
+                set_lineno = current_lineno = instr.lineno
+                lineno_pos.append(pos)
+                continue
+            if set_lineno is not None:
+                instr.lineno = set_lineno
+            elif instr.lineno is None:
+                instr.lineno = current_lineno
+            else:
+                current_lineno = instr.lineno
+
+        for i in reversed(lineno_pos):
+            del self[i]
+
+        return current_lineno
+
     def get_jump(self):
         if not self:
             return None
@@ -110,6 +135,14 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
         self.argnames = []
 
         self.add_block()
+
+    def legalize(self):
+        """Legalize all blocks.
+
+        """
+        current_lineno = self.first_lineno
+        for block in self._blocks:
+            current_lineno = block.legalize(current_lineno)
 
     def get_block_index(self, block):
         try:

--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -132,7 +132,7 @@ class ConcreteInstr(Instr):
         return cls(name, arg, lineno=lineno)
 
 
-class ConcreteBytecode(_bytecode.BaseBytecode, list):
+class ConcreteBytecode(_bytecode._BaseBytecodeList):
 
     def __init__(self, instructions=(), *, consts=(), names=(), varnames=()):
         super().__init__()
@@ -155,6 +155,13 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
                              "ConcreteInstr and SetLineno objects, "
                              "but %s was found"
                              % type(instr).__name__)
+
+    def _copy_attr_from(self, bytecode):
+        super()._copy_attr_from(bytecode)
+        if isinstance(bytecode, ConcreteBytecode):
+            self.consts = bytecode.consts
+            self.names = bytecode.names
+            self.varnames = bytecode.varnames
 
     def __repr__(self):
         return '<ConcreteBytecode instr#=%s>' % len(self)

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -32,6 +32,7 @@ class BytecodeTests(TestCase):
                      Instr("STORE_NAME", 'x'),
                      Instr("LOAD_CONST", 8, lineno=4),
                      Instr("STORE_NAME", 'y'),
+                     Label(),
                      SetLineno(5),
                      Instr("LOAD_CONST", 9, lineno=6),
                      Instr("STORE_NAME", 'z')])
@@ -41,6 +42,7 @@ class BytecodeTests(TestCase):
                                    Instr("STORE_NAME", "x", lineno=3),
                                    Instr("LOAD_CONST", 8, lineno=4),
                                    Instr("STORE_NAME", "y", lineno=4),
+                                   Label(),
                                    Instr("LOAD_CONST", 9, lineno=5),
                                    Instr("STORE_NAME", "z", lineno=5)])
 

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -57,7 +57,13 @@ class BytecodeTests(TestCase):
                      SetLineno(5),
                      Instr("LOAD_CONST", 9),
                      Instr("STORE_NAME", 'z')])
-        self.assertEqual(code, code[:])
+        sliced_code = code[:]
+        self.assertEqual(code, sliced_code)
+        for name in ("argcount", "posonlyargcount", "kwonlyargcount", "first_lineno",
+                     "name", "filename", "docstring", "cellvars", "freevars",
+                     "argnames"):
+            self.assertEqual(getattr(code, name, None),
+                             getattr(sliced_code, name, None))
 
     def test_copy(self):
         code = Bytecode()
@@ -70,7 +76,14 @@ class BytecodeTests(TestCase):
                      SetLineno(5),
                      Instr("LOAD_CONST", 9),
                      Instr("STORE_NAME", 'z')])
-        self.assertEqual(code, code.copy())
+
+        copy_code = code.copy()
+        self.assertEqual(code, copy_code)
+        for name in ("argcount", "posonlyargcount", "kwonlyargcount", "first_lineno",
+                     "name", "filename", "docstring", "cellvars", "freevars",
+                     "argnames"):
+            self.assertEqual(getattr(code, name, None),
+                             getattr(copy_code, name, None))
 
     def test_from_code(self):
         code = get_code("""

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -38,13 +38,13 @@ class BytecodeTests(TestCase):
                      Instr("STORE_NAME", 'z')])
 
         code.legalize()
-        self.assertListEqual(code,[Instr("LOAD_CONST", 7, lineno=3),
-                                   Instr("STORE_NAME", "x", lineno=3),
-                                   Instr("LOAD_CONST", 8, lineno=4),
-                                   Instr("STORE_NAME", "y", lineno=4),
-                                   Label(),
-                                   Instr("LOAD_CONST", 9, lineno=5),
-                                   Instr("STORE_NAME", "z", lineno=5)])
+        self.assertListEqual(code, [Instr("LOAD_CONST", 7, lineno=3),
+                                    Instr("STORE_NAME", "x", lineno=3),
+                                    Instr("LOAD_CONST", 8, lineno=4),
+                                    Instr("STORE_NAME", "y", lineno=4),
+                                    Label(),
+                                    Instr("LOAD_CONST", 9, lineno=5),
+                                    Instr("STORE_NAME", "z", lineno=5)])
 
     def test_slice(self):
         code = Bytecode()

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -363,6 +363,11 @@ Bytecode
 
    Methods:
 
+   .. method:: legalize()
+
+      Check the validity of all the instruction and remove the :class:`SetLineno`
+      instances after updating the instructions.
+
    .. method:: to_concrete_bytecode(compute_jumps_passes: int = None) -> ConcreteBytecode
 
       Convert to concrete bytecode with concrete instructions.
@@ -445,6 +450,12 @@ ConcreteBytecode
 
    Methods:
 
+   .. method:: legalize()
+
+      Check the validity of all the instruction and remove the :class:`SetLineno`
+      instances after updating the instructions.
+
+
    .. method:: to_code(stacksize: int = None) -> types.CodeType
 
       Convert to a Python code object.
@@ -508,6 +519,13 @@ BasicBlock
 
    Methods:
 
+   .. method:: legalize(first_lineno: int)
+
+      Check the validity of all the instruction and remove the :class:`SetLineno`
+      instances after updating the instructions. :parameter:`first_lineno` specifies
+      the line number to use for instruction without a set line number encountered
+      before the first :class:`SetLineno` instance.
+
    .. method:: get_jump()
 
       Get the target block (:class:`BasicBlock`) of the jump if the basic block
@@ -547,6 +565,10 @@ ControlFlowGraph
 
       Splits blocks after final instructions (:meth:`Instr.is_final`) and after
       conditional jumps (:meth:`Instr.is_cond_jump`).
+
+    .. method:: legalize(first_lineno: int)
+
+      Legalize all the blocks of the CFG.
 
    .. method:: add_block(instructions=None) -> BasicBlock
 
@@ -691,5 +713,5 @@ Compiler Flags
     - ASYNC_GENERATOR
 
     The async optional keyword allow to force a detected generator to be turned
-    into a generator. A code will be marked as a COROUTINE only if it contains
-    an async related instruction.
+    into an async generator. A code will be marked as a COROUTINE only if it
+    contains an async related instruction.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,16 @@
 ChangeLog
 =========
 
+unreleased: Version 0.10.0
+-------------------------
+
+New features:
+
+- Slices and copy of Bytecode, ConcreteBytecode and BasicBlock are now of the
+  same type as the original container. PR #52
+- Bytecode, ConcreteBytecode, BasicBlock and ControlFlowGraph have a new legalize
+  method validating their content and removing SetLineno. PR #52
+
 2019-12-01: Version 0.9.0
 -------------------------
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -83,7 +83,7 @@ Clearing the OPTIMIZED flag::
 
 
 The flags can be updated based on the instructions stored in the code object
-can be updated using the method update_flags.
+using the method update_flags.
 
 
 Simple loop


### PR DESCRIPTION
Currently copying/slicing a Bytecode/ConcreteBytecode object produces a normal list making some manipulations painful to perform in a natural way. This make copy and slicing type stable. I found it quite valuable to port a project that was using byteplay in the past.

It also adds a `legalize` method to Bytecode/ConcreteBytecode/BasicBlock/ControlFlowGraph which validates the instruction and remove SetLineno meta instructions.

@thautwarm @serhiy-storchaka if you can have a look it would be great.