### PR TITLE
Add Compare to __all__

### DIFF
--- a/bytecode/__init__.py
+++ b/bytecode/__init__.py
@@ -2,7 +2,7 @@ __version__ = '0.10.0.dev'
 
 __all__ = ['Label', 'Instr', 'SetLineno', 'Bytecode',
            'ConcreteInstr', 'ConcreteBytecode',
-           'ControlFlowGraph', 'CompilerFlags']
+           'ControlFlowGraph', 'CompilerFlags', 'Compare']
 
 from bytecode.flags import CompilerFlags
 from bytecode.instr import (UNSET, Label, SetLineno, Instr, CellVar, FreeVar,   # noqa

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+unreleased: Version 0.10.0
+-------------------------
+
+API changes:
+
+- Add :class:`Compare` enum to public API. PR #53
+
 2019-12-01: Version 0.9.0
 -------------------------
 


### PR DESCRIPTION
Compare is a part of the public api and should be in __all__.
Is there a reason for it not being in there?