### PR TITLE
Simplifying and enhancing const_key

### DIFF
--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -4,6 +4,7 @@ import math
 import opcode as _opcode
 import sys
 import types
+from marshal import dumps as _dumps
 
 import bytecode as _bytecode
 
@@ -27,56 +28,12 @@ UNSET = object()
 
 
 def const_key(obj):
-    # Python implmentation of the C function _PyCode_ConstantKey()
-    # of Python 3.6
-
-    obj_type = type(obj)
-    # Note: check obj_type == test_type rather than isinstance(obj, test_type)
-    # to not merge instance of subtypes
-
-    if (obj is None
-        or obj is Ellipsis
-            or obj_type in {int, bool, bytes, str, types.CodeType}):
-        return (obj_type, obj)
-
-    if obj_type == float:
-        # all we need is to make the tuple different in either the 0.0
-        # or -0.0 case from all others, just to avoid the "coercion".
-        if obj == 0.0 and math.copysign(1.0, obj) < 0:
-            return (obj_type, obj, None)
-        else:
-            return (obj_type, obj)
-
-    if obj_type == complex:
-        # For the complex case we must make complex(x, 0.)
-        # different from complex(x, -0.) and complex(0., y)
-        # different from complex(-0., y), for any x and y.
-        # All four complex zeros must be distinguished.
-        real_negzero = (obj.real == 0.0 and math.copysign(1.0, obj.real) < 0.0)
-        imag_negzero = (obj.imag == 0.0 and math.copysign(1.0, obj.imag) < 0.0)
-
-        # use True, False and None singleton as tags for the real and imag
-        # sign, to make tuples different
-        if real_negzero and imag_negzero:
-            return (obj_type, obj, True)
-        elif imag_negzero:
-            return (obj_type, obj, False)
-        elif real_negzero:
-            return (obj_type, obj, None)
-        else:
-            return (obj_type, obj)
-
-    if type(obj) == tuple:
-        key = tuple(const_key(item) for item in obj)
-        return (obj_type, obj, key)
-
-    if type(obj) == frozenset:
-        key = frozenset(const_key(item) for item in obj)
-        return (obj_type, obj, key)
-
-    # For other types, we use the object identifier as an unique identifier
-    # to ensure that they are seen as unequal.
-    return (obj_type, id(obj))
+    try:
+        return _dumps(obj)
+    except ValueError:
+        # For other types, we use the object identifier as an unique identifier
+        # to ensure that they are seen as unequal.
+        return (type(obj), id(obj))
 
 
 def _check_lineno(lineno):

--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -1,9 +1,7 @@
 import enum
 import dis
-import math
 import opcode as _opcode
 import sys
-import types
 from marshal import dumps as _dumps
 
 import bytecode as _bytecode

--- a/bytecode/tests/test_instr.py
+++ b/bytecode/tests/test_instr.py
@@ -249,8 +249,8 @@ class InstrTests(TestCase):
 
         for each in f_code:
             if (isinstance(each, Instr)
-                and each.name == 'LOAD_CONST'
-                and isinstance(each.arg, CodeType)):
+               and each.name == 'LOAD_CONST'
+               and isinstance(each.arg, CodeType)):
                 instr_load_code = each
                 break
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,10 @@ New features:
 - :class:`Bytecode`, :class:`ConcreteBytecode`, :class:`BasicBlock` and 
   :class:`ControlFlowGraph` have a new :meth:`legalize` method validating 
   their content and removing SetLineno. PR #52
+- Modify the implementation of :code:`const_key` to avoid manual
+  synchronizations with :code:`_PyCode_ConstantKey` in CPython codebase and
+  allow the use of arbitrary Python objects as constants of nested code
+  objects. #54
 
 API changes:
 


### PR DESCRIPTION
Explanation
=====================================

using `marshal.dumps` for `const_key`
---------------------------------------------------------

In CPython, code objects compiled from a source code file, are able to get serialized into binary contents via `marshal.dumps`.

This gives us some useful observations:

Constants(all elements in `code.co_consts`) of every code object, are also able to get serialized into binary contents via `marshal.dumps`.

`marshal.dumps` must be able to distinguish data of different types and values, even for something we might make mistakes on, e.g., https://github.com/vstinner/bytecode/issues/32#issuecomment-413537179, and keep the property of data with structural equality. This is because, `marshal.dumps` is a foundation of CPython: CPython relies on this to keep the same behaviour of `.py` and `.pyc`.

Hence, `marshal.dumps` can precisely give us a perfect encoding that can distinguish objects from each other and keep the equality of structure data, for all constants supported by Python. On the other side, the encoding itself is a simple `bytes`, thus, if we just want to keep the
same behaviour as CPython's, `marshal.dumps` can sufficiently become an implementation of the function `const_key` mentioned in https://github.com/vstinner/bytecode/issues/51 .

```python
def const_key(const):
    return marshal.dumps(const)
# or const_key = marshal.dumps
```

**This already keeps the total compatibility to CPython**.


More general constants in bytecode, and compatibility
----------------------------------------------------------

However, for [this good reason](https://github.com/vstinner/bytecode/issues/32#issuecomment-408626651) given by @SnoopyLane , this will be very beneficial:

> Let the bytecode library support construction of valid bytecodes, even if that means the result is not valid Python.

Hence we can also support non-`marshal`-able constants in code objects.

This time, my proposal for this extension is,

```python
def const_key(const):
    try:
        marshal.dumps(const)
    except ValueError: # un-marshal-able
        return type(const), id(const)
```

`type(const), id(const)` is also the same strategy used before: https://github.com/vstinner/bytecode/blob/45d643f6a706ae95586a874ea0fbcb18e797bfa1/bytecode/instr.py#L37 .


Advantage of this implementation
-----------------------------------------------------


1. **No need any more to synchronize our code for `const_key` with `_PyCode_ConstantKey`, but keep full compatibility to CPython**.

2. A little more efficient when we're calculating keys for `tuple` or other built-in structural data.

3. Code size for `const_key` gets reduced, also, imports of modules like `math` and `types` can get eliminated.
