### PR TITLE
flags: fix the flag inference mechanism 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     setup.py
+    bytecode/tests/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+omit =
+    setup.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise NotImplementedError
+    pass

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: python
 dist: xenial
 cache: pip
 
+branches:
+  only:
+    - master
+
 matrix:
   include:
   - python: 3.5

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -46,8 +46,6 @@ class BaseBytecode:
                 return False
         if self.kwonlyargcount != other.kwonlyargcount:
             return False
-        if self.compute_stacksize() != other.compute_stacksize():
-            return False
         if self.flags != other.flags:
             return False
         if self.first_lineno != other.first_lineno:
@@ -61,6 +59,8 @@ class BaseBytecode:
         if self.cellvars != other.cellvars:
             return False
         if self.freevars != other.freevars:
+            return False
+        if self.compute_stacksize() != other.compute_stacksize():
             return False
 
         return True
@@ -129,7 +129,7 @@ class _BaseBytecodeList(BaseBytecode, list):
             yield instr
 
     def _check_instr(self, instr):
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
 
 class _InstrList(list):

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -129,7 +129,7 @@ class _BaseBytecodeList(BaseBytecode, list):
             yield instr
 
     def _check_instr(self, instr):
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError()
 
 
 class _InstrList(list):

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -75,7 +75,7 @@ class BaseBytecode:
             value = _bytecode.CompilerFlags(value)
         self._flags = value
 
-    def update_flags(self, *, is_async=False):
+    def update_flags(self, *, is_async=None):
         self.flags = infer_flags(self, is_async)
 
 

--- a/bytecode/flags.py
+++ b/bytecode/flags.py
@@ -21,17 +21,34 @@ class CompilerFlags(IntFlag):
     GENERATOR             = 0x00020  # noqa
     NOFREE                = 0x00040  # noqa
     # New in Python 3.5
+    # Used for coroutines defined using async def ie native coroutine
     COROUTINE             = 0x00080  # noqa
+    # Used for coroutines defined as a generator and then decorated using
+    # types.coroutine
     ITERABLE_COROUTINE    = 0x00100  # noqa
     # New in Python 3.6
+    # Generator defined in an async def function
     ASYNC_GENERATOR       = 0x00200  # noqa
 
     # __future__ flags
     FUTURE_GENERATOR_STOP = 0x80000  # noqa
 
 
-def infer_flags(bytecode, is_async=False):
+def infer_flags(bytecode, is_async=None):
     """Infer the proper flags for a bytecode based on the instructions.
+
+    Because the bytecode does not have enough context to guess if a function
+    is asynchronous the algorithm tries to be conservative and will never turn
+    a previously async code into a sync one.
+
+    Parameters
+    ----------
+    bytecode : Bytecode | ConcreteBytecode | ControlFlowGraph
+        Bytecode for which to infer the proper flags
+    is_async : bool | None, optional
+        Force the code to be marked as asynchronous if True, prevent it from
+        being marked as asynchronous if False and simply infer the best
+        solution based on the opcode and the existing flag if None.
 
     """
     flags = CompilerFlags(0)
@@ -49,41 +66,84 @@ def infer_flags(bytecode, is_async=False):
                    if not isinstance(i, (_bytecode.SetLineno,
                                          _bytecode.Label))}
 
+    # Identify optimized code
     if not (instr_names & {'STORE_NAME', 'LOAD_NAME', 'DELETE_NAME'}):
         flags |= CompilerFlags.OPTIMIZED
 
+    # Check for free variables
+    if not (instr_names & {'LOAD_CLOSURE', 'LOAD_DEREF', 'STORE_DEREF',
+                           'DELETE_DEREF', 'LOAD_CLASSDEREF'}):
+        flags |= CompilerFlags.NOFREE
+
+    # Copy flags for which we cannot infer the right value
     flags |= bytecode.flags & (CompilerFlags.NEWLOCALS
                                | CompilerFlags.VARARGS
                                | CompilerFlags.VARKEYWORDS
                                | CompilerFlags.NESTED)
 
-    if instr_names & {'YIELD_VALUE', 'YIELD_FROM'}:
-        if not is_async and not bytecode.flags & CompilerFlags.ASYNC_GENERATOR:
-            flags |= CompilerFlags.GENERATOR
+    sure_generator = instr_names & {'YIELD_VALUE'}
+    maybe_generator = instr_names & {'YIELD_VALUE', 'YIELD_FROM'}
+
+    sure_async = instr_names & {'GET_AWAITABLE', 'GET_AITER', 'GET_ANEXT',
+                                'BEFORE_ASYNC_WITH', 'SETUP_ASYNC_WITH',
+                                'END_ASYNC_FOR'}
+
+    # If performing inference or forcing an async behavior, first inspect
+    # the flags since this is the only way to identify iterable coroutines
+    if is_async in (None, True):
+
+        if bytecode.flags & CompilerFlags.COROUTINE:
+            if sure_generator:
+                flags |= CompilerFlags.ASYNC_GENERATOR
+            else:
+                flags |=  CompilerFlags.COROUTINE
+        elif bytecode.flags & CompilerFlags.ITERABLE_COROUTINE:
+            if sure_async:
+                msg = ("The ITERABLE_COROUTINE flag is set but bytecode that"
+                       "can only be used in async functions have been "
+                       "detected. Please unset that flag before performing "
+                       "inference.")
+                raise ValueError(msg)
+            flags |=  CompilerFlags.ITERABLE_COROUTINE
+        elif bytecode.flags & CompilerFlags.ASYNC_GENERATOR:
+            if not sure_generator:
+                flags |=  CompilerFlags.COROUTINE
+            else:
+                flags |= CompilerFlags.ASYNC_GENERATOR
+
+        # If the code was not asynchronous before determine if it should now be
+        # asynchronous based on the opcode and the is_async argument.
         else:
-            flags |= CompilerFlags.ASYNC_GENERATOR
+            if sure_async:
+                # YIELD_FROM is not allowed in async generator
+                if sure_generator:
+                    flags |= CompilerFlags.ASYNC_GENERATOR
+                else:
+                    flags |= CompilerFlags.COROUTINE
 
-    if not (instr_names & {'LOAD_CLOSURE', 'LOAD_DEREF', 'STORE_DEREF',
-                           'DELETE_DEREF', 'LOAD_CLASSDEREF'}):
-        flags |= CompilerFlags.NOFREE
+            elif maybe_generator:
+                if is_async:
+                    if sure_generator:
+                        flags |= CompilerFlags.ASYNC_GENERATOR
+                    else:
+                        flags |= CompilerFlags.COROUTINE
+                else:
+                    flags |= CompilerFlags.GENERATOR
 
-    if (not (bytecode.flags & CompilerFlags.ITERABLE_COROUTINE
-             or flags & CompilerFlags.ASYNC_GENERATOR)
-        and (instr_names & {'GET_AWAITABLE', 'GET_AITER', 'GET_ANEXT',
-                            'BEFORE_ASYNC_WITH', 'SETUP_ASYNC_WITH'}
-             or bytecode.flags & CompilerFlags.COROUTINE)):
-        flags |= CompilerFlags.COROUTINE
+            elif is_async:
+                flags |= CompilerFlags.COROUTINE
 
-    flags |= bytecode.flags & CompilerFlags.ITERABLE_COROUTINE
+    # If the code should not be asynchronous, check first it is possible and
+    # next set the GENERATOR flag if relevant
+    else:
+        if sure_async:
+            raise ValueError("The is_async argument is False but bytecodes "
+                             "that can only be used in async functions have "
+                             "been detected.")
+
+        if maybe_generator:
+            flags |= CompilerFlags.GENERATOR
 
     flags |= bytecode.flags & CompilerFlags.FUTURE_GENERATOR_STOP
-
-    if ([bool(flags & getattr(CompilerFlags, k))
-         for k in ('COROUTINE', 'ITERABLE_COROUTINE', 'GENERATOR',
-                   'ASYNC_GENERATOR')].count(True) > 1):
-        raise ValueError("Code should not have more than one of the "
-                         "following flag set : generator, coroutine, "
-                         "iterable coroutine and async generator, got:"
-                         "%s" % flags)
 
     return flags

--- a/bytecode/flags.py
+++ b/bytecode/flags.py
@@ -96,7 +96,7 @@ def infer_flags(bytecode, is_async=None):
             if sure_generator:
                 flags |= CompilerFlags.ASYNC_GENERATOR
             else:
-                flags |=  CompilerFlags.COROUTINE
+                flags |= CompilerFlags.COROUTINE
         elif bytecode.flags & CompilerFlags.ITERABLE_COROUTINE:
             if sure_async:
                 msg = ("The ITERABLE_COROUTINE flag is set but bytecode that"
@@ -104,10 +104,10 @@ def infer_flags(bytecode, is_async=None):
                        "detected. Please unset that flag before performing "
                        "inference.")
                 raise ValueError(msg)
-            flags |=  CompilerFlags.ITERABLE_COROUTINE
+            flags |= CompilerFlags.ITERABLE_COROUTINE
         elif bytecode.flags & CompilerFlags.ASYNC_GENERATOR:
             if not sure_generator:
-                flags |=  CompilerFlags.COROUTINE
+                flags |= CompilerFlags.COROUTINE
             else:
                 flags |= CompilerFlags.ASYNC_GENERATOR
 

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import textwrap
 import unittest
-from bytecode import Label, Instr, FreeVar, Bytecode, SetLineno, ConcreteInstr
+from bytecode import (Label, Instr, FreeVar, CellVar, Bytecode, SetLineno,
+                      ConcreteInstr)
 from bytecode.tests import TestCase, get_code
 
 

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import textwrap
 import unittest
-from bytecode import (Label, Instr, FreeVar, CellVar, Bytecode, SetLineno,
-                      ConcreteInstr)
+from bytecode import Label, Instr, FreeVar, Bytecode, SetLineno, ConcreteInstr
 from bytecode.tests import TestCase, get_code
 
 

--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -184,4 +184,4 @@ class BytecodeTests(TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -179,7 +179,7 @@ class BytecodeBlocksTests(TestCase):
     def test_repr(self):
         r = repr(ControlFlowGraph())
         self.assertIn("ControlFlowGraph", r)
-        self.assertIn("0", r)
+        self.assertIn("1", r)
 
     def test_to_bytecode(self):
         # if test:

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -177,7 +177,9 @@ class BytecodeBlocksTests(TestCase):
                                 Instr("STORE_NAME", 'z', lineno=5)])
 
     def test_repr(self):
-        pass # XXX
+        r = repr(ControlFlowGraph())
+        self.assertIn("ControlFlowGraph", r)
+        self.assertIn("0", r)
 
     def test_to_bytecode(self):
         # if test:
@@ -382,7 +384,16 @@ class BytecodeBlocksFunctionalTests(TestCase):
         code2 = disassemble(source)
         self.assertEqual(code1, code2)
 
-        # XXX expand
+        # Type mismatch
+        self.assertNotEqual(code1, 1)
+
+        # argnames mismatch
+        self.assertNotEqual(code1, ControlFlowGraph())
+
+        # instr mismatch
+        cfg = ControlFlowGraph()
+        cfg.argnames = code1.argnames
+        self.assertNotEqual(code1, cfg)
 
     def check_getitem(self, code):
         # check internal Code block indexes (index by index, index by label)
@@ -392,7 +403,10 @@ class BytecodeBlocksFunctionalTests(TestCase):
             self.assertEqual(code.get_block_index(block), block_index)
 
     def test_delitem(self):
-        pass  # XXX
+        cfg = ControlFlowGraph()
+        b = cfg.add_block()
+        del cfg[b]
+        self.assertEqual(len(cfg.get_instructions()), 0)
 
     def sample_code(self):
         code = disassemble('x = 1', remove_last_return_none=True)
@@ -421,7 +435,12 @@ class BytecodeBlocksFunctionalTests(TestCase):
                                [Instr('NOP', lineno=1)])
         self.check_getitem(code)
 
-        # XXX expand
+        with self.assertRaises(TypeError):
+            code.split_block(1, 1)
+
+        with self.assertRaises(ValueError) as e:
+            code.split_block(code[0], 2)
+        self.assertIn("positive", e.exception.args[0])
 
     def test_split_block_end(self):
         code = self.sample_code()

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -176,6 +176,9 @@ class BytecodeBlocksTests(TestCase):
                                 Instr("LOAD_CONST", 9, lineno=5),
                                 Instr("STORE_NAME", 'z', lineno=5)])
 
+    def test_repr(self):
+        pass # XXX
+
     def test_to_bytecode(self):
         # if test:
         #     x = 2
@@ -379,12 +382,17 @@ class BytecodeBlocksFunctionalTests(TestCase):
         code2 = disassemble(source)
         self.assertEqual(code1, code2)
 
+        # XXX expand
+
     def check_getitem(self, code):
         # check internal Code block indexes (index by index, index by label)
         for block_index, block in enumerate(code):
             self.assertIs(code[block_index], block)
             self.assertIs(code[block], block)
             self.assertEqual(code.get_block_index(block), block_index)
+
+    def test_delitem(self):
+        pass  # XXX
 
     def sample_code(self):
         code = disassemble('x = 1', remove_last_return_none=True)
@@ -412,6 +420,8 @@ class BytecodeBlocksFunctionalTests(TestCase):
                                [Instr('STORE_NAME', 'x', lineno=1)],
                                [Instr('NOP', lineno=1)])
         self.check_getitem(code)
+
+        # XXX expand
 
     def test_split_block_end(self):
         code = self.sample_code()

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -385,15 +385,17 @@ class BytecodeBlocksFunctionalTests(TestCase):
         self.assertEqual(code1, code2)
 
         # Type mismatch
-        self.assertNotEqual(code1, 1)
+        self.assertFalse(code1 == 1)
 
         # argnames mismatch
-        self.assertNotEqual(code1, ControlFlowGraph())
+        cfg = ControlFlowGraph()
+        cfg.argnames = 10
+        self.assertFalse(code1 == cfg)
 
         # instr mismatch
         cfg = ControlFlowGraph()
         cfg.argnames = code1.argnames
-        self.assertNotEqual(code1, cfg)
+        self.assertFalse(code1 == cfg)
 
     def check_getitem(self, code):
         # check internal Code block indexes (index by index, index by label)
@@ -569,7 +571,9 @@ class CFGStacksizeComputationTests(TestCase):
         self.assertEqual(code.co_stacksize, cfg.compute_stacksize())
 
     def test_empty_code(self):
-        self.assertEqual(ControlFlowGraph().compute_stacksize(), 0)
+        cfg = ControlFlowGraph()
+        del cfg[0]
+        self.assertEqual(cfg.compute_stacksize(), 0)
 
     def test_handling_of_set_lineno(self):
         code = Bytecode()

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -439,7 +439,7 @@ class BytecodeBlocksFunctionalTests(TestCase):
             code.split_block(1, 1)
 
         with self.assertRaises(ValueError) as e:
-            code.split_block(code[0], 2)
+            code.split_block(code[0], -2)
         self.assertIn("positive", e.exception.args[0])
 
     def test_split_block_end(self):

--- a/bytecode/tests/test_code.py
+++ b/bytecode/tests/test_code.py
@@ -54,4 +54,4 @@ class CodeTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -165,7 +165,7 @@ class ConcreteBytecodeTests(TestCase):
     def test_repr(self):
         r = repr(ConcreteBytecode())
         self.assertIn("ConcreteBytecode", r)
-        self.assertIn("0", ConcreteBytecode)
+        self.assertIn("0", r)
 
     def test_eq(self):
         code = ConcreteBytecode()

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -5,7 +5,7 @@ import types
 import unittest
 import textwrap
 from bytecode import (UNSET, Label, Instr, SetLineno, Bytecode,
-                      CellVar, FreeVar,
+                      CellVar, FreeVar, CompilerFlags,
                       ConcreteInstr, ConcreteBytecode)
 from bytecode.tests import get_code, TestCase, WORDCODE
 
@@ -161,6 +161,35 @@ class ConcreteInstrTests(TestCase):
 
 
 class ConcreteBytecodeTests(TestCase):
+
+    def test_eq(self):
+        code = ConcreteBytecode()
+        self.assertNotEqual(code, 1)
+
+        for name, val in (("names", ["a"]), ("varnames", ["a"]),
+                          ("consts", [1]),
+                          ("argcount", 1), ("kwonlyargcount", 2),
+                          ("flags", CompilerFlags(CompilerFlags.GENERATOR)),
+                          ("first_lineno", 10), ("filename", "xxxx.py"),
+                          ("name", "__x"), ("docstring", "x-x-x"),
+                          ("cellvars", [CellVar("x")]),
+                          ("freevars", [FreeVar("x")])):
+                          # names, varnames, consts
+            c = ConcreteBytecode()
+            setattr(c, name, val)
+            # For obscure reasons using assertNotEqual here fail
+            self.assertFalse(code == c)
+
+        if sys.version_info > (3, 8):
+            c = ConcreteBytecode()
+            c.posonlyargcount = 10
+            self.assertFalse(code == c)
+
+        c = ConcreteBytecode()
+        c.consts = [1]
+        code.consts = [1]
+        c.append(ConcreteInstr("LOAD_CONST", 0))
+        self.assertFalse(code == c)
 
     def test_attr(self):
         code_obj = get_code("x = 5")

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -174,7 +174,6 @@ class ConcreteBytecodeTests(TestCase):
                           ("name", "__x"), ("docstring", "x-x-x"),
                           ("cellvars", [CellVar("x")]),
                           ("freevars", [FreeVar("x")])):
-                          # names, varnames, consts
             c = ConcreteBytecode()
             setattr(c, name, val)
             # For obscure reasons using assertNotEqual here fail

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -162,9 +162,14 @@ class ConcreteInstrTests(TestCase):
 
 class ConcreteBytecodeTests(TestCase):
 
+    def test_repr(self):
+        r = repr(ConcreteBytecode())
+        self.assertIn("ConcreteBytecode", r)
+        self.assertIn("0", ConcreteBytecode)
+
     def test_eq(self):
         code = ConcreteBytecode()
-        self.assertNotEqual(code, 1)
+        self.assertFalse(code == 1)
 
         for name, val in (("names", ["a"]), ("varnames", ["a"]),
                           ("consts", [1]),

--- a/bytecode/tests/test_flags.py
+++ b/bytecode/tests/test_flags.py
@@ -133,3 +133,7 @@ class FlagsTests(unittest.TestCase):
             code.flags = CompilerFlags(CompilerFlags.ITERABLE_COROUTINE)
             with self.assertRaises(ValueError):
                 code.update_flags(is_async=is_async)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/bytecode/tests/test_flags.py
+++ b/bytecode/tests/test_flags.py
@@ -7,6 +7,10 @@ from bytecode.flags import infer_flags
 
 class FlagsTests(unittest.TestCase):
 
+    def test_type_validation_on_inference(self):
+        with self.assertRaises(ValueError):
+            infer_flags(1)
+
     def test_flag_inference(self):
 
         # Check no loss of non-infered flags
@@ -35,29 +39,95 @@ class FlagsTests(unittest.TestCase):
         self.assertFalse(bool(code.flags & CompilerFlags.OPTIMIZED))
         self.assertFalse(bool(code.flags & CompilerFlags.NOFREE))
 
+    def test_async_gen_no_flag_is_async_None(self):
+        # Test inference in the absence of any flag set on the bytecode
+
         # Infer generator
         code = ConcreteBytecode()
         code.append(ConcreteInstr('YIELD_VALUE'))
-        for is_async, expected in ((False, CompilerFlags.GENERATOR),
-                                   (True, CompilerFlags.ASYNC_GENERATOR)):
-            self.assertTrue(bool(infer_flags(code, is_async) & expected))
+        self.assertTrue(bool(infer_flags(code) & CompilerFlags.GENERATOR))
 
         # Infer coroutine
         code = ConcreteBytecode()
         code.append(ConcreteInstr('GET_AWAITABLE'))
-        iter_flags = CompilerFlags(CompilerFlags.ITERABLE_COROUTINE)
-        for f, expected in ((CompilerFlags(0), True), (iter_flags, False)):
-            code.flags = f
-            self.assertEqual(bool(infer_flags(code) & CompilerFlags.COROUTINE),
-                             expected)
+        self.assertTrue(bool(infer_flags(code) & CompilerFlags.COROUTINE))
 
-        # Test check flag sanity
+        # Infer coroutine or async generator
+        for i, expected in (("YIELD_VALUE", CompilerFlags.ASYNC_GENERATOR),
+                            ("YIELD_FROM", CompilerFlags.COROUTINE)):
+            code = ConcreteBytecode()
+            code.append(ConcreteInstr('GET_AWAITABLE'))
+            code.append(ConcreteInstr(i))
+            print(i, expected, infer_flags(code))
+            self.assertTrue(bool(infer_flags(code) & expected))
+
+    def test_async_gen_no_flag_is_async_True(self):
+        # Test inference when we request an async function
+
+        # Force coroutine
+        code = ConcreteBytecode()
+        self.assertTrue(bool(infer_flags(code, True) &
+                             CompilerFlags.COROUTINE))
+
+        # Infer coroutine or async generator
+        for i, expected in (("YIELD_VALUE", CompilerFlags.ASYNC_GENERATOR),
+                            ("YIELD_FROM", CompilerFlags.COROUTINE)):
+            code = ConcreteBytecode()
+            code.append(ConcreteInstr(i))
+            print(i, expected)
+            self.assertTrue(bool(infer_flags(code, True) & expected))
+
+    def test_async_gen_no_flag_is_async_False(self):
+        # Test inference when we request a non-async function
+
+        # Infer generator
+        code = ConcreteBytecode()
         code.append(ConcreteInstr('YIELD_VALUE'))
-        code.flags = CompilerFlags(CompilerFlags.GENERATOR
-                                   | CompilerFlags.COROUTINE)
-        infer_flags(code, is_async=True)  # Just want to be sure it pases
-        with self.assertRaises(ValueError):
-            code.update_flags()
+        code.flags = CompilerFlags(CompilerFlags.COROUTINE)
+        self.assertTrue(bool(infer_flags(code, False) &
+                             CompilerFlags.GENERATOR))
 
+        # Abort on coroutine
+        code = ConcreteBytecode()
+        code.append(ConcreteInstr('GET_AWAITABLE'))
+        code.flags = CompilerFlags(CompilerFlags.COROUTINE)
         with self.assertRaises(ValueError):
-            infer_flags(None)
+            infer_flags(code, False)
+
+    # TODO
+    def test_async_gen_flags(self):
+        # Test inference in the presence of pre-existing flags
+
+        for is_async in (None, True):
+
+            # Infer generator
+            code = ConcreteBytecode()
+            code.append(ConcreteInstr('YIELD_VALUE'))
+            for f, expected in ((CompilerFlags.COROUTINE,
+                                 CompilerFlags.ASYNC_GENERATOR),
+                                (CompilerFlags.ASYNC_GENERATOR,
+                                 CompilerFlags.ASYNC_GENERATOR),
+                                (CompilerFlags.ITERABLE_COROUTINE,
+                                 CompilerFlags.ITERABLE_COROUTINE)):
+                code.flags = CompilerFlags(f)
+                self.assertTrue(bool(infer_flags(code, is_async) & expected))
+
+            # Infer coroutine
+            code = ConcreteBytecode()
+            code.append(ConcreteInstr('YIELD_FROM'))
+            for f, expected in ((CompilerFlags.COROUTINE,
+                                 CompilerFlags.COROUTINE),
+                                (CompilerFlags.ASYNC_GENERATOR,
+                                 CompilerFlags.COROUTINE),
+                                (CompilerFlags.ITERABLE_COROUTINE,
+                                 CompilerFlags.ITERABLE_COROUTINE)):
+                code.flags = CompilerFlags(f)
+                self.assertTrue(bool(infer_flags(code, is_async) & expected))
+
+            # Crash on ITERABLE_COROUTINE with async bytecode
+            code = ConcreteBytecode()
+            code.append(ConcreteInstr('GET_AWAITABLE'))
+            code.flags = CompilerFlags(CompilerFlags.ITERABLE_COROUTINE)
+            with self.assertRaises(ValueError):
+                infer_flags(code, is_async)
+

--- a/bytecode/tests/test_flags.py
+++ b/bytecode/tests/test_flags.py
@@ -69,8 +69,7 @@ class FlagsTests(unittest.TestCase):
         # Force coroutine
         code = ConcreteBytecode()
         code.update_flags(is_async=True)
-        self.assertTrue(bool(code.flags &
-                             CompilerFlags.COROUTINE))
+        self.assertTrue(bool(code.flags & CompilerFlags.COROUTINE))
 
         # Infer coroutine or async generator
         for i, expected in (("YIELD_VALUE", CompilerFlags.ASYNC_GENERATOR),
@@ -88,8 +87,7 @@ class FlagsTests(unittest.TestCase):
         code.append(ConcreteInstr('YIELD_VALUE'))
         code.flags = CompilerFlags(CompilerFlags.COROUTINE)
         code.update_flags(is_async=False)
-        self.assertTrue(bool(code.flags &
-                             CompilerFlags.GENERATOR))
+        self.assertTrue(bool(code.flags & CompilerFlags.GENERATOR))
 
         # Abort on coroutine
         code = ConcreteBytecode()
@@ -135,4 +133,3 @@ class FlagsTests(unittest.TestCase):
             code.flags = CompilerFlags(CompilerFlags.ITERABLE_COROUTINE)
             with self.assertRaises(ValueError):
                 code.update_flags(is_async=is_async)
-

--- a/bytecode/tests/test_misc.py
+++ b/bytecode/tests/test_misc.py
@@ -269,4 +269,4 @@ class MiscTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/bytecode/tests/test_misc.py
+++ b/bytecode/tests/test_misc.py
@@ -261,8 +261,10 @@ L.  6  32: LOAD_CONST 3
         self.check_dump_bytecode(code, expected, lineno=True)
 
     def test_type_validation(self):
+        class T:
+            first_lineno = 1
         with self.assertRaises(TypeError):
-            bytecode.dump_bytecode(1)
+            bytecode.dump_bytecode(T())
 
 
 class MiscTests(unittest.TestCase):

--- a/bytecode/tests/test_misc.py
+++ b/bytecode/tests/test_misc.py
@@ -260,6 +260,10 @@ L.  6  32: LOAD_CONST 3
 """.lstrip("\n")
         self.check_dump_bytecode(code, expected, lineno=True)
 
+    def test_type_validation(self):
+        with self.assertRaises(TypeError):
+            bytecode.dump_bytecode(1)
+
 
 class MiscTests(unittest.TestCase):
 

--- a/bytecode/tests/test_peephole_opt.py
+++ b/bytecode/tests/test_peephole_opt.py
@@ -819,4 +819,4 @@ class Tests(TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -404,7 +404,7 @@ Bytecode
       This computation requires to build the control flow graph associated with
       the code.
 
-    .. method:: update_flags(is_async: bool = False)
+    .. method:: update_flags(is_async: bool = None)
 
       Update the object flags by calling :py:func:infer_flags on itself.
 
@@ -480,7 +480,7 @@ ConcreteBytecode
       This computation requires to build the control flow graph associated with
       the code.
 
-   .. method:: update_flags(is_async: bool = False)
+   .. method:: update_flags(is_async: bool = None)
 
       Update the object flags by calling :py:func:infer_flags on itself.
 
@@ -596,7 +596,7 @@ ControlFlowGraph
       Compute the stack size required by a bytecode object. Will raise an
       exception if the bytecode is invalid.
 
-   .. method:: update_flags(is_async: bool = False)
+   .. method:: update_flags(is_async: bool = None)
 
       Update the object flags by calling :py:func:infer_flags on itself.
 
@@ -701,7 +701,7 @@ Compiler Flags
         has been imported from \_\_future\_\_
 
 
-.. function:: infer_flags(bytecode, async: bool = False) -> CompilerFlags
+.. function:: infer_flags(bytecode, async: bool = None) -> CompilerFlags
 
     Infer the correct values for the compiler flags for a given bytecode based
     on the instructions. The flags that can be inferred are :
@@ -712,6 +712,6 @@ Compiler Flags
     - COROUTINE
     - ASYNC_GENERATOR
 
-    The async optional keyword allow to force a detected generator to be turned
-    into an async generator. A code will be marked as a COROUTINE only if it
-    contains an async related instruction.
+    Force the code to be marked as asynchronous if True, prevent it from
+    being marked as asynchronous if False and simply infer the best
+    solution based on the opcode and the existing flag if None.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,15 @@ ChangeLog
 unreleased: Version 0.11.0
 --------------------------
 
+New features:
+
+- The :func:`infer_flags` can now be used to forcibly mark a function as
+  asynchronous or not.
+
+Bugfixes:
+
+- Fix a design flaw in the flag inference mechanism that could very easily
+  lead to invalid flags configuration PR #56
 
 2020-02-02: Version 0.10.0
 --------------------------


### PR DESCRIPTION
The existing implementation could easily generate invalid flags and was not easy to use to forcibly set a function as asynchronous or not. The new implementation address both limitations. 