### PR TITLE
Support for large scale basic blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bytecode.egg-info/
 .mypy_cache
 .spyproject
 .idea/
+.vscode/
 .coverage
 .pytest_cache
 .cache

--- a/bytecode/cfg.py
+++ b/bytecode/cfg.py
@@ -331,7 +331,7 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
         block2 = BasicBlock(instructions)
         block.next_block = block2
 
-        for block in self[block_index + 1 :]:
+        for block in self[block_index + 1:]:
             self._block_index[id(block)] += 1
 
         self._blocks.insert(block_index + 1, block2)

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -765,6 +765,30 @@ class CFGStacksizeComputationTests(TestCase):
         self.assertEqual(test.__code__.co_stacksize, 1)
         self.assertEqual(test(1), 0)
 
+    def test_huge_code_with_numerous_blocks(self):
+        def base_func(x):
+            pass
+
+        def mk_if_then_else(depth):
+            instructions = []
+            for i in range(depth):
+                label_else = Label()
+                instructions.extend([
+                    Instr("LOAD_FAST", "x"),
+                    Instr("POP_JUMP_IF_FALSE", label_else),
+                    Instr("LOAD_GLOBAL", "f{}".format(i)),
+                    Instr("RETURN_VALUE"),
+                    label_else
+                ])
+            instructions.extend([
+                Instr("LOAD_CONST", None),
+                Instr("RETURN_VALUE"),
+            ])
+            return instructions
+
+        bytecode = Bytecode(mk_if_then_else(5000))
+        bytecode.compute_stacksize()
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,8 @@ Bugfixes:
 - Fix a design flaw in the flag inference mechanism that could very easily
   lead to invalid flags configuration PR #56
 
+- Fix recursion limitations when compiling bytecode with numerous basic
+  blocks. #57
 
 2020-02-02: Version 0.10.0
 --------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Bugfixes:
 - Fix recursion limitations when compiling bytecode with numerous basic
   blocks. #57
 
+
 2020-03-02: Version 0.11.0
 --------------------------
 
@@ -21,6 +22,7 @@ Bugfixes:
 
 - Fix a design flaw in the flag inference mechanism that could very easily
   lead to invalid flags configuration PR #56
+
 
 2020-02-02: Version 0.10.0
 --------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,10 @@ ChangeLog
 unreleased: Version 0.12.0
 --------------------------
 
+Bugfixes:
+
+- Fix recursion limitations when compiling bytecode with numerous basic
+  blocks. #57
 
 2020-03-02: Version 0.11.0
 --------------------------
@@ -17,9 +21,6 @@ Bugfixes:
 
 - Fix a design flaw in the flag inference mechanism that could very easily
   lead to invalid flags configuration PR #56
-
-- Fix recursion limitations when compiling bytecode with numerous basic
-  blocks. #57
 
 2020-02-02: Version 0.10.0
 --------------------------


### PR DESCRIPTION
1. use trampoline methods to allow deep recursions for `bytecode.cfg_compute_stack_size`
2. add a testcase `test_huge_code_with_numerous_blocks` which cannot get handled previously
3. add notes to ChangeLog.rst